### PR TITLE
Collect memory stats from cgroup Memory stats file.

### DIFF
--- a/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
+++ b/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
@@ -31,7 +31,7 @@ object CGroupsMemoryHandle {
   // https://docs.docker.com/config/containers/runmetrics/
   val metrics = Seq("cache", "rss", "mapped_file", "pgpgin", "pgpgout", "swap", "active_anon", "inactive_anon",
       "active_file", "inactive_file", "unevictable", "hierarchical_memory_limit", "hierarchical_memsw_limit")
-      .flatMap { metric => Seq(metric, "total_" + metric)}
+    .flatMap { metric => Seq(metric, "total_" + metric)}
 
   val countMetrics = Set("pgpgin", "pgpgout", "total_pgpgin", "total_pgpgout")
 
@@ -44,7 +44,7 @@ object CGroupsMemoryHandle {
     }
 
   private def getMetricsSnapshot: Map[String, Long] = {
-    val memMappings = Source.fromFile(cGroupMemoryStatPath).getLines
+    Source.fromFile(cGroupMemoryStatPath).getLines
       .flatMap { case line =>
         try {
           val words = line.split(" ")
@@ -56,13 +56,6 @@ object CGroupsMemoryHandle {
           }
         }
       }.toMap
-
-    metrics.flatMap { metric =>
-      memMappings.get(metric) match {
-        case Some(value) => Seq((metric, value))
-        case None => Seq()
-      }
-    }.toMap
   }
 }
 

--- a/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
+++ b/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
@@ -1,43 +1,24 @@
 package com.cloudera.spark
 
-import com.cloudera.spark.CGroupsMemoryHandle.{cGroupMemoryStatPath, getCGroupMemStats}
+import com.cloudera.spark.CGroupsMemoryHandle.{countMetrics, metrics, getMetricsSnapshot}
 
 import scala.io.Source
 
-class CGroupsMemoryHandle(cgroupMemStats: Map[String, Long]) extends MemoryGetter {
+class CGroupsMemoryHandle extends MemoryGetter {
 
-  var orderedNames: Option[Seq[String]] = None
-
-  override val namesAndReporting: Seq[(String, PeakReporting)] = {
-    val namesAndReporting = cgroupMemStats.toSeq.map { x =>
-      if (Set("pgpgin", "pgpgout", "total_pgpgin", "total_pgpgout")(x._1)) {
-        (x._1, IncrementCounts)
-      } else {
-        (x._1, IncrementBytes)
-      }
-    }
-    orderedNames = Some(namesAndReporting.map { x => x._1})
-    namesAndReporting
+  override val namesAndReporting = metrics.map { m =>
+    val peakReporting = if (countMetrics(m)) IncrementCounts else IncrementBytes
+    (m, peakReporting)
   }
 
   override def values(dest: Array[Long], offset: Int): Unit = {
-    if (new java.io.File(cGroupMemoryStatPath).exists) {
-      var counter = 0
-      orderedNames match {
-        case Some(names) => {
-          names.foreach { name =>
-            getCGroupMemStats.get(name) match {
-              case Some(metricValue) => {
-                dest(offset + counter) = metricValue
-              }
-            }
-            // counter value is being increased irrespective of whether a value is found
-            // to ensure that the metrics are read in order. if a metric value is not
-            // found for a metric it's value is simply not updated in the dest array.
-            counter += 1
-          }
-        }
+    var idx = offset
+    val metricsSnapshot = getMetricsSnapshot
+    metrics.foreach { m =>
+      metricsSnapshot.get(m).foreach { newValue =>
+        dest(idx) = newValue
       }
+      idx += 1
     }
   }
 }
@@ -45,17 +26,24 @@ class CGroupsMemoryHandle(cgroupMemStats: Map[String, Long]) extends MemoryGette
 object CGroupsMemoryHandle {
 
   val cGroupMemoryStatPath = "/sys/fs/cgroup/memory/memory.stat"
+  // For more information about the metrics please visit
+  // https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/resource_management_guide/sec-memory
+  // https://docs.docker.com/config/containers/runmetrics/
+  val metrics = Seq("cache", "rss", "mapped_file", "pgpgin", "pgpgout", "swap", "active_anon", "inactive_anon",
+      "active_file", "inactive_file", "unevictable", "hierarchical_memory_limit", "hierarchical_memsw_limit")
+      .flatMap { metric => Seq(metric, "total_" + metric)}
+
+  val countMetrics = Set("pgpgin", "pgpgout", "total_pgpgin", "total_pgpgout")
 
   def get(): Option[CGroupsMemoryHandle] = {
     if (new java.io.File(cGroupMemoryStatPath).exists) {
-      val cgroupMemStats = getCGroupMemStats
-      Some(new CGroupsMemoryHandle(cgroupMemStats))
+      Some(new CGroupsMemoryHandle())
       } else {
         None
       }
     }
 
-  private def getCGroupMemStats: Map[String, Long] = {
+  private def getMetricsSnapshot: Map[String, Long] = {
     val memMappings = Source.fromFile(cGroupMemoryStatPath).getLines
       .flatMap { case line =>
         try {
@@ -69,18 +57,12 @@ object CGroupsMemoryHandle {
         }
       }.toMap
 
-    // For more information about the metrics please visit
-    // https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/resource_management_guide/sec-memory
-    // https://docs.docker.com/config/containers/runmetrics/
-    Seq("cache", "rss", "mapped_file", "pgpgin", "pgpgout", "swap", "active_anon", "inactive_anon",
-    "active_file", "inactive_file", "unevictable", "hierarchical_memory_limit", "hierarchical_memsw_limit")
-      .flatMap { metric => Seq(metric, "total_" + metric)}
-      .flatMap { metric =>
-        memMappings.get(metric) match {
-          case Some(value) => Seq((metric, value))
-          case None => Seq()
-        }
-      }.toMap
+    metrics.flatMap { metric =>
+      memMappings.get(metric) match {
+        case Some(value) => Seq((metric, value))
+        case None => Seq()
+      }
+    }.toMap
   }
 }
 

--- a/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
+++ b/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
@@ -1,0 +1,37 @@
+package com.cloudera.spark
+
+import scala.io.Source
+
+class CGroupsMemoryHandle(cgroupMemStats: Seq[(String, Long)]) extends MemoryGetter {
+
+  override val namesAndReporting: Seq[(String, PeakReporting)] = cgroupMemStats.map(x => {
+    (x._1, IncrementBytes)
+  })
+
+  override def values(dest: Array[Long], offset: Int): Unit = {
+    var counter = 0
+    cgroupMemStats.foreach(x => {
+      dest(offset + counter) = x._2
+      counter += 1
+    })
+  }
+}
+
+object CGroupsMemoryHandle {
+
+  val cGroupMemoryStatPath = "/sys/fs/cgroup/memory/memory.stat"
+
+  def get(): Option[CGroupsMemoryHandle] = {
+    if (new java.io.File(cGroupMemoryStatPath).exists) {
+      val cgroupMemStats = Source.fromFile(cGroupMemoryStatPath).getLines
+        .map(line => {
+          val words = line.split(" ")
+          words{0} -> words{1}.toLong
+        }).toSeq
+      Some(new CGroupsMemoryHandle(cgroupMemStats))
+      } else {
+        None
+      }
+    }
+}
+

--- a/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
+++ b/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
@@ -4,22 +4,39 @@ import com.cloudera.spark.CGroupsMemoryHandle.{cGroupMemoryStatPath, getCGroupMe
 
 import scala.io.Source
 
-class CGroupsMemoryHandle(cgroupMemStats: Seq[(String, Long)]) extends MemoryGetter {
+class CGroupsMemoryHandle(cgroupMemStats: Map[String, Long]) extends MemoryGetter {
 
-  override val namesAndReporting: Seq[(String, PeakReporting)] = cgroupMemStats.map(x =>
-    if (Set("pgpgin", "pgpgout", "total_pgpgin", "total_pgpgout")(x._1)) {
-      (x._1, IncrementCounts)
-    } else {
-      (x._1, IncrementBytes)
+  var orderedNames: Option[Seq[String]] = None
+
+  override val namesAndReporting: Seq[(String, PeakReporting)] = {
+    val namesAndReporting = cgroupMemStats.toSeq.map { x =>
+      if (Set("pgpgin", "pgpgout", "total_pgpgin", "total_pgpgout")(x._1)) {
+        (x._1, IncrementCounts)
+      } else {
+        (x._1, IncrementBytes)
+      }
     }
-  )
+    orderedNames = Some(namesAndReporting.map { x => x._1})
+    namesAndReporting
+  }
 
   override def values(dest: Array[Long], offset: Int): Unit = {
     if (new java.io.File(cGroupMemoryStatPath).exists) {
       var counter = 0
-      getCGroupMemStats.foreach{ case (_, metricValue) =>
-        dest(offset + counter) = metricValue
-        counter += 1
+      orderedNames match {
+        case Some(names) => {
+          names.foreach { name =>
+            getCGroupMemStats.get(name) match {
+              case Some(metricValue) => {
+                dest(offset + counter) = metricValue
+              }
+            }
+            // counter value is being increased irrespective of whether a value is found
+            // to ensure that the metrics are read in order. if a metric value is not
+            // found for a metric it's value is simply not updated in the dest array.
+            counter += 1
+          }
+        }
       }
     }
   }
@@ -38,8 +55,8 @@ object CGroupsMemoryHandle {
       }
     }
 
-  private def getCGroupMemStats = {
-    Source.fromFile(cGroupMemoryStatPath).getLines
+  private def getCGroupMemStats: Map[String, Long] = {
+    val memMappings = Source.fromFile(cGroupMemoryStatPath).getLines
       .flatMap { case line =>
         try {
           val words = line.split(" ")
@@ -50,7 +67,20 @@ object CGroupsMemoryHandle {
             None
           }
         }
-      }.toSeq
+      }.toMap
+
+    // For more information about the metrics please visit
+    // https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/resource_management_guide/sec-memory
+    // https://docs.docker.com/config/containers/runmetrics/
+    Seq("cache", "rss", "mapped_file", "pgpgin", "pgpgout", "swap", "active_anon", "inactive_anon",
+    "active_file", "inactive_file", "unevictable", "hierarchical_memory_limit", "hierarchical_memsw_limit")
+      .flatMap { metric => Seq(metric, "total_" + metric)}
+      .flatMap { metric =>
+        memMappings.get(metric) match {
+          case Some(value) => Seq((metric, value))
+          case None => Seq()
+        }
+      }.toMap
   }
 }
 

--- a/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
+++ b/core/src/main/scala/com/cloudera/spark/CGroupsMemoryHandle.scala
@@ -13,9 +13,16 @@ class CGroupsMemoryHandle(cgroupMemStats: Seq[(String, Long)]) extends MemoryGet
   override def values(dest: Array[Long], offset: Int): Unit = {
     var counter = 0
     Source.fromFile(cGroupMemoryStatPath).getLines
-      .map { line =>
-        val words = line.split(" ")
-        words{0} -> words{1}.toLong
+      .flatMap { case line =>
+        try {
+          val words = line.split(" ")
+          Some(words{0} -> words{1}.toLong)
+        } catch {
+          case e: Exception => {
+            e.printStackTrace()
+            None
+          }
+        }
       }.toSeq.foreach{ case (_, metricValue) =>
       dest(offset + counter) = metricValue
       counter += 1
@@ -30,9 +37,16 @@ object CGroupsMemoryHandle {
   def get(): Option[CGroupsMemoryHandle] = {
     if (new java.io.File(cGroupMemoryStatPath).exists) {
       val cgroupMemStats = Source.fromFile(cGroupMemoryStatPath).getLines
-        .map { line =>
-          val words = line.split(" ")
-          words{0} -> words{1}.toLong
+        .flatMap { case line =>
+          try {
+            val words = line.split(" ")
+            Some(words{0} -> words{1}.toLong)
+          } catch {
+            case e: Exception => {
+              e.printStackTrace()
+              None
+            }
+          }
         }.toSeq
       Some(new CGroupsMemoryHandle(cgroupMemStats))
       } else {

--- a/core/src/main/scala/com/cloudera/spark/MemoryMonitor.scala
+++ b/core/src/main/scala/com/cloudera/spark/MemoryMonitor.scala
@@ -19,6 +19,7 @@ import org.apache.spark.memory.SparkMemoryManagerHandle
 class MemoryMonitor(val args: MemoryMonitorArgs) {
   val nettyMemoryHandle = SparkNettyMemoryHandle.get()
   val sparkMemManagerHandle = SparkMemoryManagerHandle.get()
+  val cGroupsMemoryHandle = CGroupsMemoryHandle.get()
   val memoryBean = ManagementFactory.getMemoryMXBean
   val poolBeans = ManagementFactory.getMemoryPoolMXBeans.asScala
   val offHeapPoolBeans = poolBeans.filter { pool =>
@@ -37,7 +38,8 @@ class MemoryMonitor(val args: MemoryMonitorArgs) {
       offHeapPoolBeans.map(new PoolGetter(_)) ++
       bufferPoolsBeans.map(new BufferPoolGetter(_)) ++
       nettyMemoryHandle.toSeq ++
-      sparkMemManagerHandle.toSeq
+      sparkMemManagerHandle.toSeq ++
+      cGroupsMemoryHandle
 
   val namesAndReporting = getters.flatMap(_.namesAndReporting)
   val names = namesAndReporting.map(_._1)


### PR DESCRIPTION
Added the cgroup memory stats to the memory monitor plugin.

This PR created a new CgroupMemoryHandle which reads the memory.stat file to read the various parameters present in that file. Right now all the reporting for the parameters in the memory.stat file happens based in the change in bytes. This could be modified later after further Investigation into the meaning of each of these metrics.